### PR TITLE
データ最終更新日の更新

### DIFF
--- a/src/components/FacilityCard.tsx
+++ b/src/components/FacilityCard.tsx
@@ -124,7 +124,7 @@ export const FacilityCard: React.FC<FacilityCardProps> = ({ facilityId, date, co
 
             <div className="mt-1 flex items-end justify-between">
                 <div className="flex flex-col min-w-0 w-full">
-                    <span className="text-sm font-semibold text-slate-700 break-words">{nextChangeText || 'See details'}</span>
+                    <span className="text-sm font-semibold text-slate-700 break-words">{nextChangeText}</span>
                 </div>
             </div>
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -72,8 +72,8 @@ export const translations: Record<string, Record<Language, string>> = {
     'about.title': { ja: 'アプリについて', en: 'About' },
     'about.disclaimer_title': { ja: '免責事項 (Beta版)', en: 'Disclaimer (Beta)' },
     'about.disclaimer_text': {
-        ja: '本アプリは個人が開発・運営する非公式のベータ版です。\n\nデータの正確性について: 本アプリは外部サイト（大学公式サイト等）のデータを参照し、独自のロジックで判定を行っています。そのため、元データが未公開の場合や、学事予定が急遽変更された場合、表示内容に誤りが生じる可能性が高いことをあらかじめご了承ください。\n\n公式サイトの確認: 重要な予定がある場合は、必ず各施設の公式サイトおよび掲示板を併せてご確認ください。\n\n責任の所在: 本アプリの利用により生じた不利益や損害について、開発者は一切の責任を負いかねます。',
-        en: 'This is an unofficial beta app.\n\nData Accuracy: This app determines schedules based on external data (official sites, etc.) using custom logic. Please note that errors may occur if original data is unpublished or schedules change suddenly.\n\nOfficial Verification: For important events, please always verify with official websites and bulletin boards.\n\nLiability: The developer assumes no responsibility for any disadvantages or damages arising from the use of this app.'
+        ja: '本アプリについて\n本アプリは、個人が開発・運営を行っている非公式のサービスです。\n\n情報の正確性について\n本アプリは、大学公式サイト等の外部データを参照し、独自のロジックを用いて情報を表示しています。システムの運用には万全を期しておりますが、元データの更新遅延や学事予定の急な変更により、実際の状況と異なる情報が表示される可能性があります。あらかじめご了承ください。\n\n公式サイトの確認\n重要な予定や正確な時間を確認する必要がある場合は、必ず各施設・大学の公式サイトおよび掲示板を併せてご確認ください。\n\n免責事項\n本アプリの利用により生じた不利益や損害について、開発者は一切の責任を負いかねます。利用者自身の判断と責任においてご利用ください。',
+        en: 'About App\nThis is an unofficial service developed and operated by an individual.\n\nData Accuracy\nThis app references external data (official university websites, etc.) and uses custom logic to display information. While we strive to ensure system accuracy, please note that information may differ from actual status due to delays in data updates or sudden changes in academic schedules.\n\nOfficial Verification\nFor important schedules or precise times, please ensure to check the official websites and bulletin boards of each facility/university.\n\nDisclaimer\nThe developer assumes no responsibility for any disadvantages or damages arising from the use of this app. Please use it at your own discretion and responsibility.'
     },
     'about.last_updated': { ja: 'データ最終更新日', en: 'Data Last Updated' },
     'about.stale_warning': { ja: '※古い情報が含まれている可能性があります', en: '※Data may be outdated' },
@@ -95,7 +95,7 @@ export const translations: Record<string, Record<Language, string>> = {
 
     // First Visit Modal
     'first_visit.title': { ja: 'ご利用前の確認', en: 'Important Notice' },
-    'first_visit.text': { ja: '本アプリは外部サイトのデータを参照しています。元データが未公開の場合は誤りが生じる可能性が高いことをご了承ください。', en: 'This app references data from external sites. Please note that errors are highly likely if the original data is unpublished.' },
+    'first_visit.text': { ja: '本アプリは外部データを参照しています。取得タイミングや元データの公開状況により、正確性を保証できない場合があります。', en: 'This app references external data. Accuracy cannot be guaranteed depending on data retrieval timing or availability.' },
     'first_visit.disagree': { ja: '了解しない', en: 'Disagree' },
     'first_visit.agree': { ja: '了解', en: 'Agree' },
 };

--- a/src/lib/schedules.ts
+++ b/src/lib/schedules.ts
@@ -476,4 +476,4 @@ export const SCHEDULES: Record<FacilityId, ScheduleRule[]> = Object.fromEntries(
     Object.entries(CONST_SCHEDULE_DATA).map(([id, data]) => [id, data.rules])
 ) as Record<FacilityId, ScheduleRule[]>;
 
-export const DATA_LAST_UPDATED = '2026-01-10'; // YYYY-MM-DD
+export const DATA_LAST_UPDATED = '2026-01-15'; // YYYY-MM-DD

--- a/src/lib/status-utils.ts
+++ b/src/lib/status-utils.ts
@@ -122,7 +122,7 @@ export function calculateFacilityStatus(
         return {
             status: 'closed',
             statusText: t(closedTextKey),
-            nextChangeText: 'Next: Check Calendar',
+            nextChangeText: '',
             isOpen: false,
             alert: matchedRule?.note ? t(matchedRule.note) : undefined
         };


### PR DESCRIPTION
変更内容まとめ
「カレンダーを確認」「詳細」の削除
閉館時などに表示されていた「カレンダーを確認 (Next: Check Calendar)」や「詳細 (See details)」というテキストを削除し、見た目をシンプルにしました。
初回起動時のメッセージ変更
「ご利用前の確認」の内容を、データの正確性と取得タイミングに関するより具体的な免責文言に変更しました。
アプリについて（About）の免責事項更新
「情報の正確性」「公式サイトの確認」「免責事項」のセクションを明確に分けた詳細なテキストに更新しました。
データ最終更新日の更新
2026-01-15 に更新しました。
