### PR TITLE
UI/UXの変更

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { DATA_LAST_UPDATED } from '../lib/schedules';
-import { X, ExternalLink, Info } from 'lucide-react';
+import { X, ExternalLink, Info, AlertTriangle, ShieldAlert, Globe } from 'lucide-react';
 
 interface AboutModalProps {
     isOpen: boolean;
@@ -30,6 +30,29 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
 
     if (!isOpen) return null;
 
+    const SECTIONS = [
+        {
+            icon: Info,
+            titleKey: 'about.section.about.title',
+            contentKey: 'about.section.about.content'
+        },
+        {
+            icon: AlertTriangle,
+            titleKey: 'about.section.accuracy.title',
+            contentKey: 'about.section.accuracy.content'
+        },
+        {
+            icon: Globe,
+            titleKey: 'about.section.official.title',
+            contentKey: 'about.section.official.content'
+        },
+        {
+            icon: ShieldAlert,
+            titleKey: 'about.section.disclaimer.title',
+            contentKey: 'about.section.disclaimer.content'
+        }
+    ];
+
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
             <div
@@ -55,20 +78,29 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
                 </div>
 
                 {/* Content */}
-                <div className="p-6 overflow-y-auto space-y-6">
-                    {/* Disclaimer */}
-                    <div className="p-4 bg-amber-50 border border-amber-100 rounded-xl space-y-2">
-                        <h3 className="text-sm font-bold text-amber-800 flex items-center gap-2">
-                            {t('about.disclaimer_title')}
-                        </h3>
-                        <p className="text-sm text-amber-700 leading-relaxed whitespace-pre-wrap">
-                            {t('about.disclaimer_text')}
-                        </p>
+                <div className="p-6 overflow-y-auto space-y-8">
+                    {/* Sections */}
+                    <div className="space-y-6">
+                        {SECTIONS.map((section, i) => (
+                            <div key={i} className="flex gap-4">
+                                <div className="mt-0.5 shrink-0">
+                                    <section.icon className="w-5 h-5 text-calm-subtext" />
+                                </div>
+                                <div className="space-y-1">
+                                    <h3 className="text-xs font-bold text-calm-subtext uppercase tracking-wider">
+                                        {t(section.titleKey)}
+                                    </h3>
+                                    <p className="text-sm text-calm-text leading-relaxed">
+                                        {t(section.contentKey)}
+                                    </p>
+                                </div>
+                            </div>
+                        ))}
                     </div>
 
                     {/* Links */}
-                    <div className="space-y-3">
-                        <h3 className="text-sm font-bold text-calm-subtext uppercase tracking-wider">
+                    <div className="space-y-3 pt-2 border-t border-slate-100">
+                        <h3 className="text-xs font-bold text-calm-subtext uppercase tracking-wider mt-4">
                             {t('about.official_links')}
                         </h3>
                         <div className="grid gap-2">
@@ -111,7 +143,7 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
                         </div>
                     </div>
 
-                    <div className="pt-4 text-center space-y-2">
+                    <div className="pt-4 text-center space-y-2 border-t border-slate-100">
                         <div className="text-xs text-slate-500">
                             {t('about.last_updated')}: {new Date(DATA_LAST_UPDATED).toLocaleDateString(language === 'ja' ? 'ja-JP' : 'en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
                         </div>

--- a/src/components/AdminBuildingCard.tsx
+++ b/src/components/AdminBuildingCard.tsx
@@ -65,19 +65,19 @@ export const AdminBuildingCard: React.FC<AdminBuildingCardProps> = ({ date, onSe
     return (
         <div className="bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden">
             {/* Main Building Header */}
-            <button
-                onClick={() => onSelectFacility(mainId)}
-                className="w-full p-4 bg-slate-50/30 text-left hover:bg-slate-50 transition-colors group"
+            {/* Main Building Header */}
+            <div
+                className="w-full p-4 bg-slate-50/30 text-left"
             >
                 <div className="flex justify-between items-center mb-1">
-                    <h3 className="font-bold text-calm-text text-base group-hover:text-accent transition-colors">
+                    <h3 className="font-bold text-calm-text text-base">
                         {mainName}
                     </h3>
                     <span className="text-calm-subtext">
                         {/* Status hidden as requested */}
                     </span>
                 </div>
-            </button>
+            </div>
 
             {/* Sub Departments List */}
             <div className="flex flex-col">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -61,7 +61,6 @@ export const Dashboard: React.FC = () => {
                         <FacilityCard facilityId="store" date={date} onClick={() => setSelectedFacility('store')} />
                         <FacilityCard facilityId="sabor_2f" date={date} onClick={() => setSelectedFacility('sabor_2f')} />
                     </div>
-                    <FacilityCard facilityId="cafe_castalia" date={date} onClick={() => setSelectedFacility('cafe_castalia')} />
                 </section>
 
                 <section className="space-y-4">

--- a/src/components/FacilityCard.tsx
+++ b/src/components/FacilityCard.tsx
@@ -112,7 +112,14 @@ export const FacilityCard: React.FC<FacilityCardProps> = ({ facilityId, date, co
                         <Icon size={24} className={styles.text} />
                     </div>
                     <div className="min-w-0 flex-1">
-                        <h3 className="font-bold text-calm-text text-sm md:text-base leading-tight whitespace-normal break-words">{displayName}</h3>
+                        <h3 className="font-bold text-calm-text text-sm md:text-base leading-tight whitespace-normal break-words">
+                            {displayName.split('\n').map((line, i, arr) => (
+                                <span key={i}>
+                                    {line}
+                                    {i < arr.length - 1 && <br className="hidden lg:block" />}
+                                </span>
+                            ))}
+                        </h3>
 
                     </div>
                 </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -70,10 +70,26 @@ export const translations: Record<string, Record<Language, string>> = {
 
     // About Page
     'about.title': { ja: 'アプリについて', en: 'About' },
-    'about.disclaimer_title': { ja: '免責事項 (Beta版)', en: 'Disclaimer (Beta)' },
-    'about.disclaimer_text': {
-        ja: '本アプリについて\n本アプリは、個人が開発・運営を行っている非公式のサービスです。\n\n情報の正確性について\n本アプリは、大学公式サイト等の外部データを参照し、独自のロジックを用いて情報を表示しています。システムの運用には万全を期しておりますが、元データの更新遅延や学事予定の急な変更により、実際の状況と異なる情報が表示される可能性があります。あらかじめご了承ください。\n\n公式サイトの確認\n重要な予定や正確な時間を確認する必要がある場合は、必ず各施設・大学の公式サイトおよび掲示板を併せてご確認ください。\n\n免責事項\n本アプリの利用により生じた不利益や損害について、開発者は一切の責任を負いかねます。利用者自身の判断と責任においてご利用ください。',
-        en: 'About App\nThis is an unofficial service developed and operated by an individual.\n\nData Accuracy\nThis app references external data (official university websites, etc.) and uses custom logic to display information. While we strive to ensure system accuracy, please note that information may differ from actual status due to delays in data updates or sudden changes in academic schedules.\n\nOfficial Verification\nFor important schedules or precise times, please ensure to check the official websites and bulletin boards of each facility/university.\n\nDisclaimer\nThe developer assumes no responsibility for any disadvantages or damages arising from the use of this app. Please use it at your own discretion and responsibility.'
+    // About Sections
+    'about.section.about.title': { ja: '本アプリについて', en: 'About App' },
+    'about.section.about.content': { ja: '本アプリは、個人が開発・運営を行っている非公式のサービスです。', en: 'This is an unofficial service developed and operated by an individual.' },
+
+    'about.section.accuracy.title': { ja: '情報の正確性について', en: 'Data Accuracy' },
+    'about.section.accuracy.content': {
+        ja: '本アプリは、大学公式サイト等の外部データを参照し、独自のロジックを用いて情報を表示しています。システムの運用には万全を期しておりますが、元データの更新遅延や学事予定の急な変更により、実際の状況と異なる情報が表示される可能性があります。あらかじめご了承ください。',
+        en: 'This app references external data (official university websites, etc.) and uses custom logic to display information. While we strive to ensure system accuracy, please note that information may differ from actual status due to delays in data updates or sudden changes in academic schedules.'
+    },
+
+    'about.section.official.title': { ja: '公式サイトの確認', en: 'Official Verification' },
+    'about.section.official.content': {
+        ja: '重要な予定や正確な時間を確認する必要がある場合は、必ず各施設・大学の公式サイトおよび掲示板を併せてご確認ください。',
+        en: 'For important schedules or precise times, please ensure to check the official websites and bulletin boards of each facility/university.'
+    },
+
+    'about.section.disclaimer.title': { ja: '免責事項', en: 'Disclaimer' },
+    'about.section.disclaimer.content': {
+        ja: '本アプリの利用により生じた不利益や損害について、開発者は一切の責任を負いかねます。利用者自身の判断と責任においてご利用ください。',
+        en: 'The developer assumes no responsibility for any disadvantages or damages arising from the use of this app. Please use it at your own discretion and responsibility.'
     },
     'about.last_updated': { ja: 'データ最終更新日', en: 'Data Last Updated' },
     'about.stale_warning': { ja: '※古い情報が含まれている可能性があります', en: '※Data may be outdated' },

--- a/src/lib/schedules.ts
+++ b/src/lib/schedules.ts
@@ -240,7 +240,7 @@ export const CONST_SCHEDULE_DATA: Record<FacilityId, FacilityData> = {
         ]
     },
     sabor_2f: {
-        name: '2階食堂さぼおる',
+        name: '2階食堂\nさぼおる',
         nameEn: 'Cafeteria Sabor (2F)',
         category: 'facility',
         unpublishedFrom: '2026-04-01',
@@ -264,7 +264,7 @@ export const CONST_SCHEDULE_DATA: Record<FacilityId, FacilityData> = {
         ].map(r => r.type === 'weekday' ? { ...r, isClosed: true } : r)
     },
     store: {
-        name: '購買書籍部ハッチポッチ',
+        name: '購買書籍部\nハッチポッチ',
         nameEn: 'Co-op Store Hatchpotch',
         category: 'facility',
         unpublishedFrom: '2026-04-01',


### PR DESCRIPTION
- 「本部管理棟」のヘッダー部分をクリック不可（非ボタン化）にしました。

- ダッシュボードの「SHOPS & SERVICES」セクションから、カフェ・カスタリアのカードを削除しました。

- - データ更新: schedules.ts の施設名に改行コードを追加しました。
- コンポーネント更新: FacilityCard.tsx で改行コードを検出し、大画面（PCなど）では改行タグ <br> として表示し、モバイル画面では改行せずに連続して表示するようにしました。
- 構造化: テキストを構造化データとして管理するように変更しました。
- アイコン追加: 各セクション（About, 正確性, 公式リンク, 免責）に適切なアイコン（Info, Alert, Globe, Shield）を追加しました。
- デザイン改善: タイトルを「公式サイトリンク」と同じスタイル（グレー・太字・大文字）に統一し、アイコンと並べることで視認性と「Coolさ」を向上させました。
- レイアウト: セクション間の余白を適切に取り、読みやすく清潔感のあるデザインにしました。